### PR TITLE
RequestCertificate: specify ProviderName in the request

### DIFF
--- a/Request-Certificate.ps1
+++ b/Request-Certificate.ps1
@@ -204,6 +204,7 @@ KeyLength = 2048
 KeySpec=1
 Exportable = TRUE
 RequestType = PKCS10
+ProviderName = "Microsoft Enhanced Cryptographic Provider v1.0"
 [RequestAttributes]
 CertificateTemplate = "$TemplateName"
 "@


### PR DESCRIPTION
Seen a mix of certutil causing a prompt to insert a smart card through to actual errors on some certificate templates stating that no provider has been specified.