### PR TITLE
Fix mangled SAN when using AddCNinSAN

### DIFF
--- a/Request-Certificate.ps1
+++ b/Request-Certificate.ps1
@@ -287,7 +287,7 @@ CertificateTemplate = "$TemplateName"
     }
 
     if ($AddCNinSAN) {
-        $SAN = "DNS=$CN" + $SAN #Add CN as first SAN entry
+        $SAN = $("DNS=$CN") + $SAN #Add CN as first SAN entry
     }
 
     # Remove Potential duplicates (if CN was already provided in SAN list)


### PR DESCRIPTION
The previous code was converting the array to a sting then adding the CN to the front of a string. This will resolve Issue $19