### PR TITLE
Fixed encoding option when exporting to pfx.

### DIFF
--- a/Request-Certificate.ps1
+++ b/Request-Certificate.ps1
@@ -414,7 +414,7 @@ CertificateTemplate = "$TemplateName"
             else {
                 $pfxPath = ".\$filename.pfx"
             }
-            $certbytes | Set-Content -Encoding Byte -Path $pfxPath -ea Stop
+            $certbytes | Set-Content -AsByteStream -Path $pfxPath -ea Stop
             Write-Host "Certificate successfully exported to `"$pfxPath`"!" -ForegroundColor Green
 		    
             Write-Verbose "deleting exported certificate from computer store"


### PR DESCRIPTION
When using your script, I came across an interesting issue when using the -Export flag.  The certificate was created properly in my local certificate store, but the script threw an error.  After some research, it appears as if powershell (.net??) has updated their options.